### PR TITLE
fix: missing discernible text for x3d viewer zoom buttons

### DIFF
--- a/src/components/X3DElement.jsx
+++ b/src/components/X3DElement.jsx
@@ -82,13 +82,21 @@ class X3DElement extends Component {
             </scene>
             <div className="controls">
               <div className="tooltip-wrapper">
-                <button onClick={this.zoomIn}>
+                <button
+                  onClick={this.zoomIn}
+                  type="button"
+                  aria-label="Zoom in"
+                >
                   <i className="far fa-plus-circle"></i>
                 </button>
                 <span className="viewer-tooltip">Zoom In</span>
               </div>
               <div className="tooltip-wrapper">
-                <button onClick={this.zoomOut}>
+                <button
+                  onClick={this.zoomOut}
+                  type="button"
+                  aria-label="Zoom out"
+                >
                   <i className="far fa-minus-circle"></i>
                 </button>
                 <span className="viewer-tooltip">Zoom Out</span>

--- a/src/components/X3DElement.jsx
+++ b/src/components/X3DElement.jsx
@@ -82,22 +82,16 @@ class X3DElement extends Component {
             </scene>
             <div className="controls">
               <div className="tooltip-wrapper">
-                <button
-                  onClick={this.zoomIn}
-                  type="button"
-                  aria-label="Zoom in"
-                >
+                <button onClick={this.zoomIn}>
                   <i className="far fa-plus-circle"></i>
+                  <span className="sr-only">Zoom in</span>
                 </button>
                 <span className="viewer-tooltip">Zoom In</span>
               </div>
               <div className="tooltip-wrapper">
-                <button
-                  onClick={this.zoomOut}
-                  type="button"
-                  aria-label="Zoom out"
-                >
+                <button onClick={this.zoomOut}>
                   <i className="far fa-minus-circle"></i>
+                  <span className="sr-only">Zoom out</span>
                 </button>
                 <span className="viewer-tooltip">Zoom Out</span>
               </div>


### PR DESCRIPTION
## Add accessible names to zoom buttons in x3dom.


## 🔗 Asana, 4Help, and Related Links [REQUIRED]  
Dubbot Ticket: https://vt.dubbot.com/a/64f127d95b662f000170637e/tasks/697913684cfa815952578c30/

## ✨ What Does This Pull Request Do?  [REQUIRED]
Add discernible text for X3D viewer zoom in/out buttons.

   
## 🛠️ Summary of Changes [REQUIRED]
**Provide an overview of the technical changes and any relevant details. 
List key updates, features added/removed, or issues addressed.**   
- Added `aria-label` to zoom buttons with icons only. 

   
## 🧪 How Should PR Be Tested? [REQUIRED]
- Go to any archive page with X3D viewer such as: https://kl-a11y.d1n265krqy0ld3.amplifyapp.com/archive/cc466p0r
- Use axedev tools browser extension to confirm the missing discernible text for zoom button is resolved
- Use screen reader to verify accessible names for the zoom buttons are announced ("Zoom In" and "Zoom Out")


   
## ♿ Accessibility Testing [REQUIRED]
**Complete standard accessibility testing and provide additional test steps/details, if applicable:**  
- [x] Does this PR change anything in the front-end? This includes backend-only changes that may affect front end components (data schema changes, global configs, package version updates, etc.)

**If "Yes", provide test environment details and complete or mark N/A all of the following tests:**

OS/Browser/Screen reader details: *For Example: macOS Tahoe 26.0.1, Google Chrome v141.0.7390.55, VoiceOver v10*

- [x] Complete an axe DevTools full or partial page scans and link it here ([axe DevTools scanning docs](https://docs.deque.com/devtools-for-web/4/en/devtools-scanning))
- [x] Keyboard navigability: Focus ring showing on all focusable/interactive elements in expected order, standard interaction present ([keyboard testing basics](https://knowbility.org/blog/2018/keyboard-testing-basics/))
- [x] Screen reader comprehension: No elements hidden from screen reader, alt text, no repeated text ([screen reader keyboard shortcuts](https://dequeuniversity.com/screenreaders/)) 
- [x] Color contrast at least WCAG AA ([contrast checker](https://webaim.org/resources/contrastchecker/))
- [x] Accessible markup used (e.g., proper heading levels, labels, roles, and semantic HTML as much as possible)  
- [ ] Other accessibility testing (please describe):  

   
## 👥 Interested Parties  
@ervinkellym 

Tag any reviewers or stakeholders you'd like to include in the discussion:   

---

🚨[REQUIRED] -  Required fields/information in the pull request
