### PR TITLE
Collection Filter/Sort Dropdowns

### DIFF
--- a/src/components/ResultsNumberDropdown.js
+++ b/src/components/ResultsNumberDropdown.js
@@ -1,5 +1,4 @@
 import { Component } from "react";
-import { Dropdown } from "semantic-ui-react";
 
 class ResultsNumberDropdown extends Component {
   constructor(props) {
@@ -9,11 +8,11 @@ class ResultsNumberDropdown extends Component {
     };
   }
 
-  handleChange = (event, result) => {
+  handleChange = (event) => {
     this.setState({
-      selectedLimit: result.value
+      selectedLimit: event.target.value
     });
-    this.props.setLimit(event, result);
+    this.props.setLimit(event, { value: event.target.value });
   };
 
   formatActiveDisplayText = () => {
@@ -40,18 +39,20 @@ class ResultsNumberDropdown extends Component {
     ];
     return (
       <>
-        <Dropdown
-          title="Items per page"
-          selection
-          compact
-          text={this.formatActiveDisplayText()}
-          value={this.state.selectedLimit}
-          options={numberOptions}
-          onChange={this.handleChange}
-          aria-label="Results per page"
-          aria-haspopup="listbox"
-          className={this.props.className || ""}
-        />
+        <div className={`${this.props.className || ""}`.trim()}>
+          <label htmlFor="results-number-dropdown">Results per page:</label>
+          <select
+            id="results-number-dropdown"
+            defaultValue="10"
+            onChange={this.handleChange}
+          >
+            {numberOptions.map((option) => (
+              <option key={option.key} value={option.value}>
+                {option.value}
+              </option>
+            ))}
+          </select>
+        </div>
       </>
     );
   }

--- a/src/components/SortOrderDropdown.js
+++ b/src/components/SortOrderDropdown.js
@@ -5,8 +5,8 @@ class SortOrderDropdown extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      sortField: "title",
-      sortDirection: "asc"
+      sortField: props.sortOpt?.field || "title",
+      sortDirection: props.sortOpt?.direction || "asc"
     };
     this.sortFieldOptions = [
       {

--- a/src/components/SortOrderDropdown.js
+++ b/src/components/SortOrderDropdown.js
@@ -1,5 +1,6 @@
 import { Component } from "react";
-import { Button, Dropdown, Icon } from "semantic-ui-react";
+import { Icon } from "semantic-ui-react";
+import "../css/Select.scss";
 
 class SortOrderDropdown extends Component {
   constructor(props) {
@@ -8,7 +9,31 @@ class SortOrderDropdown extends Component {
       sortField: props.sortOpt?.field || "title",
       sortDirection: props.sortOpt?.direction || "asc"
     };
-    this.sortFieldOptions = [
+  }
+
+  handleFieldChange = (e) => {
+    this.setState((prevState) => ({
+      ...prevState,
+      sortField: e.target.value
+    }));
+    if (typeof this.props.setSortOrder === "function") {
+      this.props.setSortOrder(e.target.value, this.state.sortDirection);
+    }
+  };
+
+  handleSortOrderChange = () => {
+    const newSortOrder = this.state.sortDirection === "asc" ? "desc" : "asc";
+    this.setState((prevState) => ({
+      ...prevState,
+      sortDirection: newSortOrder
+    }));
+    if (typeof this.props.setSortOrder === "function") {
+      this.props.setSortOrder(this.state.sortField, newSortOrder);
+    }
+  };
+
+  render() {
+    const sortFieldOptions = [
       {
         key: "title",
         text: "Title",
@@ -70,44 +95,9 @@ class SortOrderDropdown extends Component {
         value: "tags"
       }
     ];
-  }
-
-  handleFieldChange = (_, result) => {
-    this.setState((prevState) => ({
-      ...prevState,
-      sortField: result.value
-    }));
-    if (typeof this.props.setSortOrder === "function") {
-      this.props.setSortOrder(result.value, this.state.sortDirection);
-    }
-  };
-
-  handleSortOrderChange = () => {
-    const newSortOrder = this.state.sortDirection === "asc" ? "desc" : "asc";
-    this.setState((prevState) => ({
-      ...prevState,
-      sortDirection: newSortOrder
-    }));
-    if (typeof this.props.setSortOrder === "function") {
-      this.props.setSortOrder(this.state.sortField, newSortOrder);
-    }
-  };
-
-  formatActiveDisplayText = () => {
-    try {
-      const currentSortOpt = this.sortFieldOptions.find(
-        (option) => option.value === this.state.sortField
-      );
-      return `Sort by ${currentSortOpt.text}`;
-    } catch (err) {
-      console.error(err);
-    }
-  };
-
-  render() {
     return (
       <>
-        <Dropdown
+        {/* <Dropdown
           selection
           compact
           scrolling
@@ -119,21 +109,38 @@ class SortOrderDropdown extends Component {
           aria-haspopup="listbox"
           className="mr-2"
           title="Sort fields"
-        />
-        <Button
-          basic
-          icon
+        /> */}
+        <div className="select-dropdown mr-2">
+          <label htmlFor="sort-opt-dropdown">Sort By:</label>
+          <select
+            id="sort-opt-dropdown"
+            defaultValue="title"
+            onChange={this.handleFieldChange}
+          >
+            {sortFieldOptions.map((option) => (
+              <option key={option.key} value={option.value}>
+                {option.text}
+              </option>
+            ))}
+          </select>
+        </div>
+        <button
+          type="button"
           className="sort-btn"
-          title="Sort order"
-          aria-label="Sort order button"
           onClick={this.handleSortOrderChange}
         >
           {this.state.sortDirection === "asc" ? (
-            <Icon name="sort content ascending" className="sort-btn-icon" />
+            <>
+              <Icon name="sort amount up" className="sort-btn-icon" />
+              <span className="sr-only">Sort order: ascending</span>
+            </>
           ) : (
-            <Icon name="sort content descending" className="sort-btn-icon" />
+            <>
+              <Icon name="sort amount down" className="sort-btn-icon" />
+              <span className="sr-only">Sort order: descending</span>
+            </>
           )}
-        </Button>
+        </button>
       </>
     );
   }

--- a/src/components/SortbyDropdown.js
+++ b/src/components/SortbyDropdown.js
@@ -1,5 +1,5 @@
-import React, { Component } from "react";
-import { Dropdown } from "semantic-ui-react";
+import { Component } from "react";
+import "../css/Select.scss";
 
 class SortbyDropdown extends Component {
   constructor(props) {
@@ -36,10 +36,10 @@ class SortbyDropdown extends Component {
     }));
   };
 
-  updateSort = (e, { value }) => {
-    this.setState({ selectedValue: value });
+  updateSort = (e) => {
+    this.setState({ selectedValue: e.target.value });
 
-    let opt_arr = value.split(" ");
+    let opt_arr = e.target.value.split(" ");
     let sort = {
       field: opt_arr[0],
       direction: opt_arr[1]
@@ -48,22 +48,20 @@ class SortbyDropdown extends Component {
   };
 
   render() {
-    let selectedOpt = this.state.selectedValue.split(" ");
-    const text = `${this.formatField(selectedOpt[0])} ${this.formatDirection(
-      selectedOpt[0],
-      selectedOpt[1]
-    )}`;
     return (
-      <div className="form-group">
-        <label id="sort-label">Sort by</label>
-        <Dropdown
-          text={text}
-          selection
-          options={this.valueOptions()}
+      <div className="select-dropdown">
+        <label htmlFor="sort-opt-dropdown">Sort By:</label>
+        <select
+          id="sort-opt-dropdown"
+          defaultValue="title asc"
           onChange={this.updateSort}
-          aria-labelledby="sort-label"
-          aria-haspopup="listbox"
-        />
+        >
+          {this.valueOptions().map((option) => (
+            <option key={option.key} value={option.value}>
+              {option.text}
+            </option>
+          ))}
+        </select>
       </div>
     );
   }

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -434,10 +434,21 @@ div.collection-item .item-image img {
 }
 
 .collection-items-list-wrapper .sort-btn {
-  padding: 11px !important;
-  margin: 0 !important;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  width: 2.5rem;
+  aspect-ratio: 1 / 1;
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+  font-size: 0.9rem;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  border-radius: 0.24rem;
+  background-color: transparent;
 }
 
-.collection-items-list-wrapper .sort-btn .sort-btn-icon {
-  font-size: 0.98rem;
+.collection-items-list-wrapper .sort-btn:focus-visible {
+  outline: var(--focus_outline);
+  outline-offset: var(--focus-outline__offset);
 }

--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -446,9 +446,10 @@ div.collection-item .item-image img {
   border: 1px solid rgba(0, 0, 0, 0.5);
   border-radius: 0.24rem;
   background-color: transparent;
-}
 
-.collection-items-list-wrapper .sort-btn:focus-visible {
-  outline: var(--focus_outline);
-  outline-offset: var(--focus-outline__offset);
+  &:focus-visible,
+  &:focus {
+    outline: var(--focus_outline);
+    outline-offset: var(--focus-outline__offset);
+  }
 }

--- a/src/css/Select.scss
+++ b/src/css/Select.scss
@@ -1,0 +1,19 @@
+.select-dropdown {
+  display: inline-flex;
+  align-items: center;
+  font-family: "gineso-condensed", sans-serif;
+  font-size: 1.1rem;
+  label {
+    margin-bottom: 0;
+    margin-right: 0.5rem;
+  }
+  select {
+    padding: 0.45rem 0.65rem;
+    font-family: "gineso-condensed", sans-serif;
+    border-radius: 0.28rem;
+  }
+  select:focus-visible {
+    outline: var(--focus_outline);
+    outline-offset: var(--focus-outline__offset);
+  }
+}

--- a/src/css/Select.scss
+++ b/src/css/Select.scss
@@ -11,6 +11,9 @@
     padding: 0.45rem 0.65rem;
     font-family: "gineso-condensed", sans-serif;
     border-radius: 0.28rem;
+    border: 1px solid rgba(0, 0, 0, 0.5);
+    border-radius: 0.24rem;
+    background-color: transparent;
   }
   select:focus-visible {
     outline: var(--focus_outline);

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -39,7 +39,7 @@ class ArchivePage extends Component {
     super(props);
     this.state = {
       item: null,
-      parentCollection: null,
+      topLevelParentCollection: null,
       collectionCustomKey: "",
       page: 0,
       category: "archive",
@@ -87,9 +87,9 @@ class ArchivePage extends Component {
       const collectionCustomKey = topLevelParentCollection.custom_key;
       const archiveSchema = this.buildArchiveSchema(item);
       this.setState({
-        item: item,
-        collectionCustomKey: collectionCustomKey,
-        topLevelParentCollection: topLevelParentCollection,
+        item,
+        collectionCustomKey,
+        topLevelParentCollection,
         info: archiveSchema,
         title_data: { item: { ...item }, collection: { ...collection } },
         title_template: getTitleTemplateForType(item, collection)
@@ -436,7 +436,7 @@ class ArchivePage extends Component {
                       data={this.state.item}
                       site={this.props.site}
                       defaultExpand={false}
-                      parentCollection={this.state.parentCollection}
+                      parentCollection={this.state.topLevelParentCollection}
                     />
                     <CollapsibleCard
                       title="Location"

--- a/src/pages/collections/BrowseCollections/BrowseCollections.tsx
+++ b/src/pages/collections/BrowseCollections/BrowseCollections.tsx
@@ -111,7 +111,10 @@ export const BrowseCollections: FC<Props> = ({ scrollUp, site }) => {
                   updateFormState={handleSetView}
                   pageViews={["Gallery", "List"]}
                 />
-                <ResultsNumberDropdown setLimit={handleResultsNumberDropdown} />
+                <ResultsNumberDropdown
+                  className="select-dropdown"
+                  setLimit={handleResultsNumberDropdown}
+                />
               </div>
             </div>
           </div>

--- a/src/pages/collections/CollectionsShowPage/CollectionItems.tsx
+++ b/src/pages/collections/CollectionsShowPage/CollectionItems.tsx
@@ -4,6 +4,7 @@ import Pagination from "../../../components/Pagination";
 import ResultsNumberDropdown from "../../../components/ResultsNumberDropdown";
 import SortOrderDropdown from "../../../components/SortOrderDropdown";
 import { Thumbnail } from "../../../components/Thumbnail";
+import "../../../css/Select.scss";
 import { language_codes } from "../../../lib/language_codes";
 import { RenderItems, arkLinkFormatted } from "../../../lib/MetadataRenderer";
 import { useGetCollectionItems } from "./useGetCollectionItems";
@@ -53,7 +54,7 @@ export const CollectionItems: FC<Props> = ({
             <div className="display-option-container">
               <ResultsNumberDropdown
                 setLimit={handleResultsNumberDropdown}
-                className="page-cnt-dropdown mr-2"
+                className="select-dropdown mr-2"
               />
               <SortOrderDropdown
                 sortOpt={sortOpt}

--- a/src/pages/search/SearchResults.js
+++ b/src/pages/search/SearchResults.js
@@ -14,6 +14,7 @@ import { faFilter } from "@fortawesome/free-solid-svg-icons";
 import { labelAttr } from "../../lib/MetadataRenderer";
 import "../../css/ListPages.scss";
 import "../../css/SearchResult.scss";
+import "../../css/Select.scss";
 
 class SearchResults extends Component {
   constructor(props) {
@@ -219,7 +220,10 @@ class SearchResults extends Component {
                     />
                   </div>
                   <div className="view-options">
-                    <ResultsNumberDropdown setLimit={this.props.setLimit} />
+                    <ResultsNumberDropdown
+                      setLimit={this.props.setLimit}
+                      className="select-dropdown"
+                    />
                     <ViewBar
                       view={this.props.view}
                       updateFormState={this.props.updateFormState}


### PR DESCRIPTION
## Improve accessibility of collection filter and sort dropdown controls, minor bug fix

## 🔗 Asana, 4Help, and Related Links [REQUIRED]  
**Asana Ticket**: https://app.asana.com/1/955176856078227/project/1210742763721034/task/1213841055468391?focus=true


## ✨ What Does This Pull Request Do?  [REQUIRED]
Improve the accessibility of collection filter and sort controls by replacing custom dropdowns with semantic form elements and clarifying sort behavior.

## 🛠️ Summary of Changes [REQUIRED]
- Replaced custom Semantic UI dropdown widgets with native `select` elements for the sort field and results-per-page controls.
- Updated the sort order control from a framework button to a semantic HTML `button`.
- Added screen-reader-only text to the sort order button so ascending/descending state is announced.
- Improved keyboard focus visibility for dropdowns and the sort button
- Fixed sort order initialization so the control reflects the current active sort state correctly.
- Fixed a bug in Citation component where the ArchivePage didn't set the parent collection correctly.

## 🧪 How Should PR Be Tested? [REQUIRED]
- go to [generated preview](https://kl-a11y.d1n265krqy0ld3.amplifyapp.com/)
- open a collection items page `/collection`
- change the results-per-page value to 10, 50, and 100 and verify the result count updates correctly
- confirm the sort field dropdown renders as a native select with a visible label
- change the sort field and verify results update using the selected field
- toggle the sort order button and verify results switch between ascending and descending
- navigate to the controls using keyboard only with Tab and confirm each control is reachable
- verify the dropdowns and sort button show a visible focus state when keyboard-focused
- with a screen reader, verify the dropdown labels are announced correctly
- with a screen reader, verify the sort order button announces whether sorting is ascending or descending

   
## ♿ Accessibility Testing [REQUIRED]
**Complete standard accessibility testing and provide additional test steps/details, if applicable:**  
- [x] Does this PR change anything in the front-end? This includes backend-only changes that may affect front end components (data schema changes, global configs, package version updates, etc.)

**If "Yes", provide test environment details and complete or mark N/A all of the following tests:**

OS/Browser/Screen reader details: *For Example: macOS Tahoe 26.0.1, Google Chrome v141.0.7390.55, VoiceOver v10*

- [x] Complete an axe DevTools full or partial page scans and link it here ([axe DevTools scanning docs](https://docs.deque.com/devtools-for-web/4/en/devtools-scanning))
- [x] Keyboard navigability: Focus ring showing on all focusable/interactive elements in expected order, standard interaction present ([keyboard testing basics](https://knowbility.org/blog/2018/keyboard-testing-basics/))
- [x] Screen reader comprehension: No elements hidden from screen reader, alt text, no repeated text ([screen reader keyboard shortcuts](https://dequeuniversity.com/screenreaders/)) 
- [x] Color contrast at least WCAG AA ([contrast checker](https://webaim.org/resources/contrastchecker/))
- [x] Accessible markup used (e.g., proper heading levels, labels, roles, and semantic HTML as much as possible)  
- [ ] Other accessibility testing (please describe):  

   
## 👥 Interested Parties  

Tag any reviewers or stakeholders you'd like to include in the discussion:  
@ervinkellym @whunter @goynejennifer @padma012 

---

🚨[REQUIRED] -  Required fields/information in the pull request
