### PR TITLE
Archive metadata collapsible cards and citation UI

### DIFF
--- a/src/components/Citation.tsx
+++ b/src/components/Citation.tsx
@@ -2,8 +2,8 @@ import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tooltip } from "@mui/material";
 
-import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import "../css/Citation.scss";
 import "../css/Typography.scss";
@@ -18,8 +18,8 @@ const Citation = ({ item, site, parentCollection }: Props) => {
   const [tabValue, setTabValue] = useState("citation");
   const [copiedCitation, setCopiedCitation] = useState(false);
   const [copiedBibTeX, setCopiedBibTeX] = useState(false);
-  const citationTabRef = useRef<HTMLButtonElement | null>(null);
-  const bibTeXTabRef = useRef<HTMLButtonElement | null>(null);
+  const citationTabRef = useRef<HTMLAnchorElement | null>(null);
+  const bibTeXTabRef = useRef<HTMLAnchorElement | null>(null);
   const citationCopyTimerRef = useRef<NodeJS.Timeout | null>(null);
   const bibTeXCopyTimerRef = useRef<NodeJS.Timeout | null>(null);
   const copyCooldown = 1000;
@@ -166,7 +166,7 @@ const Citation = ({ item, site, parentCollection }: Props) => {
     }
   };
 
-  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+  const handleKeyDown = (event: KeyboardEvent<HTMLAnchorElement>) => {
     if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
       event.preventDefault();
       const nextTab = tabValue === "citation" ? "bibtex" : "citation";
@@ -181,45 +181,53 @@ const Citation = ({ item, site, parentCollection }: Props) => {
 
   const citationObj = getCitation();
   return (
-    <div className="citation">
-      <div
+    <div className="citation typography-wrapper">
+      <ul
         className="citation-tab-list"
         role="tablist"
         aria-label="Citation formats"
       >
-        <button
-          id="citation-tab"
-          ref={citationTabRef}
-          type="button"
-          role="tab"
-          aria-selected={tabValue === "citation"}
-          aria-controls="citation-panel"
-          tabIndex={tabValue === "citation" ? 0 : -1}
-          className={`citation-tab${
-            tabValue === "citation" ? " is-active" : ""
-          }`}
-          onClick={() => setTabValue("citation")}
-          onKeyDown={handleKeyDown}
-        >
-          Citation
-        </button>
-        <button
-          id="bibtex-tab"
-          ref={bibTeXTabRef}
-          type="button"
-          role="tab"
-          aria-selected={tabValue === "bibtex"}
-          aria-controls="bibtex-panel"
-          tabIndex={tabValue === "bibtex" ? 0 : -1}
-          onKeyDown={handleKeyDown}
-          className={`citation-tab${tabValue === "bibtex" ? " is-active" : ""}`}
-          onClick={() => setTabValue("bibtex")}
-        >
-          BibTeX
-        </button>
-      </div>
+        <li role="presentation">
+          <a
+            id="citation-tab"
+            role="tab"
+            href="#citation-panel"
+            tabIndex={tabValue === "citation" ? 0 : -1}
+            className={`citation-tab${
+              tabValue === "citation" ? " is-active" : ""
+            }`}
+            onClick={(e) => {
+              e.preventDefault();
+              setTabValue("citation");
+            }}
+            onKeyDown={handleKeyDown}
+            ref={citationTabRef}
+          >
+            Citation
+          </a>
+        </li>
+        <li role="presentation">
+          <a
+            id="bibtex-tab"
+            role="tab"
+            href="#bibtex-panel"
+            tabIndex={tabValue === "bibtex" ? 0 : -1}
+            className={`citation-tab${
+              tabValue === "bibtex" ? " is-active" : ""
+            }`}
+            onClick={(e) => {
+              e.preventDefault();
+              setTabValue("bibtex");
+            }}
+            onKeyDown={handleKeyDown}
+            ref={bibTeXTabRef}
+          >
+            BibTeX
+          </a>
+        </li>
+      </ul>
 
-      <div
+      <section
         id="citation-panel"
         role="tabpanel"
         aria-labelledby="citation-tab"
@@ -276,9 +284,9 @@ const Citation = ({ item, site, parentCollection }: Props) => {
           </span>
           <span>{`accessed ${citationObj.accessDate}`}</span>
         </p>
-      </div>
+      </section>
 
-      <div
+      <section
         id="bibtex-panel"
         role="tabpanel"
         aria-labelledby="bibtex-tab"
@@ -326,7 +334,7 @@ const Citation = ({ item, site, parentCollection }: Props) => {
         <pre>
           <code aria-labelledby="bibtex-preview-heading">{bibTeXCitation}</code>
         </pre>
-      </div>
+      </section>
     </div>
   );
 };

--- a/src/components/Citation.tsx
+++ b/src/components/Citation.tsx
@@ -183,9 +183,9 @@ const Citation = ({ item, site, parentCollection }: Props) => {
 
         <TabPanel value="citation" className="citation-tab-content">
           <div className="copy-button-container">
-            <p id="citation-preview-heading" className="heading">
+            <h3 id="citation-preview-heading" className="heading">
               Citation Preview
-            </p>
+            </h3>
 
             <Tooltip
               title={copiedCitation ? "Copied!" : ""}
@@ -220,7 +220,7 @@ const Citation = ({ item, site, parentCollection }: Props) => {
             </Tooltip>
           </div>
 
-          <div
+          <p
             className="citation-text"
             aria-labelledby="citation-preview-heading"
           >
@@ -234,14 +234,14 @@ const Citation = ({ item, site, parentCollection }: Props) => {
               </a>
             </span>
             <span>{`accessed ${citationObj.accessDate}`}</span>
-          </div>
+          </p>
         </TabPanel>
 
         <TabPanel value="bibtex" className="citation-tab-content">
           <div className="copy-button-container">
-            <p id="bibtex-preview-heading" className="heading">
+            <h3 id="bibtex-preview-heading" className="heading">
               BibTeX Preview
-            </p>
+            </h3>
 
             <Tooltip
               title={copiedBibTeX ? "Copied!" : ""}

--- a/src/components/Citation.tsx
+++ b/src/components/Citation.tsx
@@ -1,33 +1,28 @@
 import { faCopy } from "@fortawesome/free-regular-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tooltip } from "@mui/material";
-import Box from "@mui/material/Box";
-import Tab from "@mui/material/Tab";
-import TabContext from "@mui/lab/TabContext";
-import TabList from "@mui/lab/TabList";
-import TabPanel from "@mui/lab/TabPanel";
 
 import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
 
 import "../css/Citation.scss";
+import "../css/Typography.scss";
 
-interface Props {
+type Props = {
   item: Archive;
   site: Site;
   parentCollection: Collection;
-}
+};
 
 const Citation = ({ item, site, parentCollection }: Props) => {
   const [tabValue, setTabValue] = useState("citation");
   const [copiedCitation, setCopiedCitation] = useState(false);
   const [copiedBibTeX, setCopiedBibTeX] = useState(false);
+  const citationTabRef = useRef<HTMLButtonElement | null>(null);
+  const bibTeXTabRef = useRef<HTMLButtonElement | null>(null);
   const citationCopyTimerRef = useRef<NodeJS.Timeout | null>(null);
   const bibTeXCopyTimerRef = useRef<NodeJS.Timeout | null>(null);
   const copyCooldown = 1000;
-
-  const handleTabChange = (_: React.SyntheticEvent, newValue: string) => {
-    setTabValue(newValue);
-  };
 
   useEffect(() => {
     return () => {
@@ -170,119 +165,168 @@ const Citation = ({ item, site, parentCollection }: Props) => {
       );
     }
   };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>) => {
+    if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+      event.preventDefault();
+      const nextTab = tabValue === "citation" ? "bibtex" : "citation";
+      setTabValue(nextTab);
+      if (nextTab === "citation") {
+        citationTabRef.current?.focus();
+      } else {
+        bibTeXTabRef.current?.focus();
+      }
+    }
+  };
+
   const citationObj = getCitation();
   return (
     <div className="citation">
-      <TabContext value={tabValue}>
-        <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
-          <TabList onChange={handleTabChange}>
-            <Tab label="Citation" value="citation" className="citation-tab" />
-            <Tab label="BibTeX" value="bibtex" className="citation-tab" />
-          </TabList>
-        </Box>
+      <div
+        className="citation-tab-list"
+        role="tablist"
+        aria-label="Citation formats"
+      >
+        <button
+          id="citation-tab"
+          ref={citationTabRef}
+          type="button"
+          role="tab"
+          aria-selected={tabValue === "citation"}
+          aria-controls="citation-panel"
+          tabIndex={tabValue === "citation" ? 0 : -1}
+          className={`citation-tab${
+            tabValue === "citation" ? " is-active" : ""
+          }`}
+          onClick={() => setTabValue("citation")}
+          onKeyDown={handleKeyDown}
+        >
+          Citation
+        </button>
+        <button
+          id="bibtex-tab"
+          ref={bibTeXTabRef}
+          type="button"
+          role="tab"
+          aria-selected={tabValue === "bibtex"}
+          aria-controls="bibtex-panel"
+          tabIndex={tabValue === "bibtex" ? 0 : -1}
+          onKeyDown={handleKeyDown}
+          className={`citation-tab${tabValue === "bibtex" ? " is-active" : ""}`}
+          onClick={() => setTabValue("bibtex")}
+        >
+          BibTeX
+        </button>
+      </div>
 
-        <TabPanel value="citation" className="citation-tab-content">
-          <div className="copy-button-container">
-            <h3 id="citation-preview-heading" className="heading">
-              Citation Preview
-            </h3>
+      <div
+        id="citation-panel"
+        role="tabpanel"
+        aria-labelledby="citation-tab"
+        className="citation-tab-content"
+        hidden={tabValue !== "citation"}
+      >
+        <div className="copy-button-container">
+          <h3 id="citation-preview-heading" className="heading">
+            Citation Preview
+          </h3>
 
-            <Tooltip
-              title={copiedCitation ? "Copied!" : ""}
-              arrow
-              open={copiedCitation === true}
-              slotProps={{
-                popper: {
-                  modifiers: [
-                    {
-                      name: "offset",
-                      options: {
-                        offset: [0, -6]
-                      }
+          <Tooltip
+            title={copiedCitation ? "Copied!" : ""}
+            arrow
+            open={copiedCitation === true}
+            slotProps={{
+              popper: {
+                modifiers: [
+                  {
+                    name: "offset",
+                    options: {
+                      offset: [0, -6]
                     }
-                  ]
-                }
-              }}
-            >
-              <button
-                type="button"
-                className="btn btn-secondary citation-copy-button"
-                onClick={onCopyCitation}
-                disabled={copiedCitation}
-              >
-                <FontAwesomeIcon
-                  icon={faCopy}
-                  className="mr-1"
-                  aria-hidden={true}
-                />
-                <span>Copy Citation</span>
-              </button>
-            </Tooltip>
-          </div>
-
-          <p
-            className="citation-text"
-            aria-labelledby="citation-preview-heading"
+                  }
+                ]
+              }
+            }}
           >
-            {citationObj.creator && <span>{citationObj.creator}</span>}
-            <span className="title">{citationObj.title}</span>
-            <span>{citationObj.dlpInstance}</span>
-            <span>{citationObj.sponsor}</span>
-            <span>
-              <a href={citationObj.permalink || "#"} className="mr-1">
-                {citationObj.permalink || "N/A"}
-              </a>
-            </span>
-            <span>{`accessed ${citationObj.accessDate}`}</span>
-          </p>
-        </TabPanel>
-
-        <TabPanel value="bibtex" className="citation-tab-content">
-          <div className="copy-button-container">
-            <h3 id="bibtex-preview-heading" className="heading">
-              BibTeX Preview
-            </h3>
-
-            <Tooltip
-              title={copiedBibTeX ? "Copied!" : ""}
-              arrow
-              open={copiedBibTeX === true}
-              slotProps={{
-                popper: {
-                  modifiers: [
-                    {
-                      name: "offset",
-                      options: {
-                        offset: [0, -6]
-                      }
-                    }
-                  ]
-                }
-              }}
+            <button
+              type="button"
+              className="btn btn-secondary citation-copy-button"
+              onClick={onCopyCitation}
+              disabled={copiedCitation}
             >
-              <button
-                type="button"
-                className="btn btn-secondary citation-copy-button"
-                onClick={onCopyBibTeXCitation}
-                disabled={copiedBibTeX}
-              >
-                <FontAwesomeIcon
-                  icon={faCopy}
-                  className="mr-1"
-                  aria-hidden={true}
-                />
-                <span>Copy Citation</span>
-              </button>
-            </Tooltip>
-          </div>
+              <FontAwesomeIcon
+                icon={faCopy}
+                className="mr-1"
+                aria-hidden={true}
+              />
+              <span>Copy Citation</span>
+            </button>
+          </Tooltip>
+        </div>
 
-          <pre>
-            <code aria-labelledby="bibtex-preview-heading">
-              {bibTeXCitation}
-            </code>
-          </pre>
-        </TabPanel>
-      </TabContext>
+        <p className="citation-text" aria-labelledby="citation-preview-heading">
+          {citationObj.creator && <span>{citationObj.creator}</span>}
+          <span className="title">{citationObj.title}</span>
+          <span>{citationObj.dlpInstance}</span>
+          <span>{citationObj.sponsor}</span>
+          <span>
+            <a href={citationObj.permalink || "#"} className="mr-1">
+              {citationObj.permalink || "N/A"}
+            </a>
+          </span>
+          <span>{`accessed ${citationObj.accessDate}`}</span>
+        </p>
+      </div>
+
+      <div
+        id="bibtex-panel"
+        role="tabpanel"
+        aria-labelledby="bibtex-tab"
+        className="citation-tab-content"
+        hidden={tabValue !== "bibtex"}
+      >
+        <div className="copy-button-container">
+          <h3 id="bibtex-preview-heading" className="heading">
+            BibTeX Preview
+          </h3>
+
+          <Tooltip
+            title={copiedBibTeX ? "Copied!" : ""}
+            arrow
+            open={copiedBibTeX === true}
+            slotProps={{
+              popper: {
+                modifiers: [
+                  {
+                    name: "offset",
+                    options: {
+                      offset: [0, -6]
+                    }
+                  }
+                ]
+              }
+            }}
+          >
+            <button
+              type="button"
+              className="btn btn-secondary citation-copy-button"
+              onClick={onCopyBibTeXCitation}
+              disabled={copiedBibTeX}
+            >
+              <FontAwesomeIcon
+                icon={faCopy}
+                className="mr-1"
+                aria-hidden={true}
+              />
+              <span>Copy Citation</span>
+            </button>
+          </Tooltip>
+        </div>
+
+        <pre>
+          <code aria-labelledby="bibtex-preview-heading">{bibTeXCitation}</code>
+        </pre>
+      </div>
     </div>
   );
 };

--- a/src/components/Citation.tsx
+++ b/src/components/Citation.tsx
@@ -243,6 +243,8 @@ const Citation = ({ item, site, parentCollection }: Props) => {
             title={copiedCitation ? "Copied!" : ""}
             arrow
             open={copiedCitation === true}
+            aria-live="assertive"
+            aria-atomic="true"
             slotProps={{
               popper: {
                 modifiers: [
@@ -260,7 +262,6 @@ const Citation = ({ item, site, parentCollection }: Props) => {
               type="button"
               className="btn btn-secondary citation-copy-button"
               onClick={onCopyCitation}
-              disabled={copiedCitation}
             >
               <FontAwesomeIcon
                 icon={faCopy}
@@ -302,6 +303,8 @@ const Citation = ({ item, site, parentCollection }: Props) => {
             title={copiedBibTeX ? "Copied!" : ""}
             arrow
             open={copiedBibTeX === true}
+            aria-live="assertive"
+            aria-atomic="true"
             slotProps={{
               popper: {
                 modifiers: [
@@ -319,7 +322,6 @@ const Citation = ({ item, site, parentCollection }: Props) => {
               type="button"
               className="btn btn-secondary citation-copy-button"
               onClick={onCopyBibTeXCitation}
-              disabled={copiedBibTeX}
             >
               <FontAwesomeIcon
                 icon={faCopy}

--- a/src/components/CollapsibleCards.js
+++ b/src/components/CollapsibleCards.js
@@ -1,16 +1,15 @@
 import { faCopyright } from "@fortawesome/free-regular-svg-icons";
 import {
   faAngleDown,
-  faAngleRight,
   faBookOpen,
   faCircleInfo,
   faLocationDot
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useState } from "react";
 import { htmlParsedValue } from "src/lib/MetadataRenderer";
 import Citation from "../components/Citation";
 import "../css/CollapsibleCards.scss";
+import "../css/Typography.scss";
 import { LeafletThumb } from "./LeafletThumb";
 
 const single_value_headers = [
@@ -144,28 +143,20 @@ const getCopyrightData = (data) => {
   let key1 = "rights_holder";
   let key2 = "rights";
   return (
-    <ul className="data-list">
+    <dl className="data-list">
       {data[key1] && (
-        <li className="data-list-item">
-          <h3 className="data-list-label">{modifyKey(key1)}</h3>
-          <div className="data-list-value">
-            <p className="data-list-value-text">
-              {htmlParsedValue(data[key1])}
-            </p>
-          </div>
-        </li>
+        <div className="data-list-item">
+          <dt className="data-list-label">{modifyKey(key1)}</dt>
+          <dd className="data-list-value">{htmlParsedValue(data[key1])}</dd>
+        </div>
       )}
       {data[key2] && (
-        <li className="data-list-item">
-          <h3 className="data-list-label">{modifyKey(key2)}</h3>
-          <div className="data-list-value">
-            <p className="data-list-value-text">
-              {htmlParsedValue(data[key2])}
-            </p>
-          </div>
-        </li>
+        <div className="data-list-item">
+          <dt className="data-list-label">{modifyKey(key2)}</dt>
+          <dd className="data-list-value">{htmlParsedValue(data[key2])}</dd>
+        </div>
       )}
-    </ul>
+    </dl>
   );
 };
 
@@ -177,14 +168,7 @@ export default function CollapsibleCard({
   defaultExpand,
   parentCollection
 }) {
-  const [expanded, setExpanded] = useState(defaultExpand ?? true);
-
-  const handleExpandClick = (e) => {
-    e.preventDefault();
-    setExpanded((prev) => !prev);
-  };
-
-  let facetSearchItems = [
+  const facetSearchItems = [
     "format",
     "format_physical",
     "medium",
@@ -238,12 +222,12 @@ export default function CollapsibleCard({
     ];
 
     return (
-      <ul className="data-list">
+      <dl className="data-list">
         {single_value_headers.map((key) =>
           data[key] && !items.includes(key) ? (
-            <li key={key} className="data-list-item">
-              <h3 className="data-list-label">{modifyKey(key)}</h3>
-              <p className="data-list-value">
+            <div key={key} className="data-list-item">
+              <dt className="data-list-label">{modifyKey(key)}</dt>
+              <dd className="data-list-value">
                 {typeof data[key] === "string" &&
                 data[key].startsWith("http") ? (
                   <a href={data[key]} target="_blank" rel="noopener noreferrer">
@@ -252,32 +236,24 @@ export default function CollapsibleCard({
                 ) : (
                   data[key]
                 )}
-              </p>
-            </li>
+              </dd>
+            </div>
           ) : null
         )}
 
         {multi_value_headers.map((key) =>
           data[key] && !items.includes(key) && data[key].length > 0 ? (
-            <li key={key} className="data-list-item">
-              <h3 className="data-list-label">{modifyKey(key)}</h3>
-              <div className="data-list-value">
-                {Array.isArray(data[key]) ? (
-                  data[key].map((value, index) => (
-                    <p key={index} className="data-list-value-text">
-                      {renderContent(key, value)}
-                    </p>
-                  ))
-                ) : (
-                  <p className="data-list-value-text">
-                    {renderContent(key, data[key])}
-                  </p>
-                )}
-              </div>
-            </li>
+            <div key={key} className="data-list-item">
+              <dt className="data-list-label">{modifyKey(key)}</dt>
+              {data[key].map((value, index) => (
+                <dd key={index} className="data-list-value">
+                  {renderContent(key, value)}
+                </dd>
+              ))}
+            </div>
           ) : null
         )}
-      </ul>
+      </dl>
     );
   };
 
@@ -300,28 +276,19 @@ export default function CollapsibleCard({
     }
   };
 
-  const getCollapsibleArrow = () => {
-    return expanded ? (
-      <FontAwesomeIcon
-        className="expand-icon"
-        icon={faAngleDown}
-        aria-hidden="true"
-      />
-    ) : (
-      <FontAwesomeIcon
-        className="expand-icon"
-        icon={faAngleRight}
-        aria-hidden="true"
-      />
-    );
-  };
-
   return (
-    <details className="card-details" open={expanded}>
-      <summary className="card-summary" onClick={handleExpandClick}>
+    <details
+      className="card-details typography-wrapper"
+      open={defaultExpand ?? true}
+    >
+      <summary className="card-summary">
         {getMarker(marker)}
         {title}
-        {getCollapsibleArrow()}
+        <FontAwesomeIcon
+          className="expand-icon"
+          icon={faAngleDown}
+          aria-hidden="true"
+        />
       </summary>
       <div className="card-content">
         {getContent(marker, data, site, parentCollection)}

--- a/src/components/CollapsibleCards.js
+++ b/src/components/CollapsibleCards.js
@@ -1,32 +1,17 @@
-import * as React from "react";
-import { styled } from "@mui/material/styles";
-import Card from "@mui/material/Card";
-import CardHeader from "@mui/material/CardHeader";
-import CardContent from "@mui/material/CardContent";
-import CardActions from "@mui/material/CardActions";
-import Collapse from "@mui/material/Collapse";
-import IconButton from "@mui/material/IconButton";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import LocationOnIcon from "@mui/icons-material/LocationOn";
-import InfoIcon from "@mui/icons-material/Info";
-import CopyrightIcon from "@mui/icons-material/Copyright";
-import LocalLibraryIcon from "@mui/icons-material/LocalLibrary";
-import { LeafletThumb } from "./LeafletThumb";
-import Citation from "../components/Citation";
-
-import "../css/CollapsibleCards.scss";
+import { faCopyright } from "@fortawesome/free-regular-svg-icons";
+import {
+  faAngleDown,
+  faAngleRight,
+  faBookOpen,
+  faCircleInfo,
+  faLocationDot
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { useState } from "react";
 import { htmlParsedValue } from "src/lib/MetadataRenderer";
-
-const ExpandMore = styled((props) => {
-  const { expand, ...other } = props;
-  return <IconButton {...other} />;
-})(({ theme, expand }) => ({
-  transform: !expand ? "rotate(0deg)" : "rotate(180deg)",
-  marginLeft: "auto",
-  transition: theme.transitions.create("transform", {
-    duration: theme.transitions.duration.shortest
-  })
-}));
+import Citation from "../components/Citation";
+import "../css/CollapsibleCards.scss";
+import { LeafletThumb } from "./LeafletThumb";
 
 const single_value_headers = [
   "bibliographic_citation",
@@ -84,17 +69,39 @@ const multi_value_headers = [
 const getMarker = (marker) => {
   switch (marker) {
     case "location":
-      return <LocationOnIcon style={{ color: "#ffffff", fontSize: "0.8em" }} />;
+      return (
+        <FontAwesomeIcon
+          icon={faLocationDot}
+          aria-hidden="true"
+          className="card-summary-icon"
+        />
+      );
 
     case "about":
-      return <InfoIcon style={{ color: "#ffffff", fontSize: "0.8em" }} />;
+      return (
+        <FontAwesomeIcon
+          icon={faCircleInfo}
+          aria-hidden="true"
+          className="card-summary-icon"
+        />
+      );
 
     case "copyright":
-      return <CopyrightIcon style={{ color: "#ffffff", fontSize: "0.8em" }} />;
+      return (
+        <FontAwesomeIcon
+          icon={faCopyright}
+          aria-hidden="true"
+          className="card-summary-icon"
+        />
+      );
 
     case "citation":
       return (
-        <LocalLibraryIcon style={{ color: "#ffffff", fontSize: "0.8em" }} />
+        <FontAwesomeIcon
+          icon={faBookOpen}
+          aria-hidden="true"
+          className="card-summary-icon"
+        />
       );
 
     default:
@@ -137,34 +144,28 @@ const getCopyrightData = (data) => {
   let key1 = "rights_holder";
   let key2 = "rights";
   return (
-    <table style={{ width: "100%", borderCollapse: "collapse" }}>
-      <tbody>
-        {data[key1] && (
-          <tr>
-            <td
-              style={{ padding: "4px 2px", verticalAlign: "top", width: "30%" }}
-            >
-              <h6 key={key1}>{`${modifyKey(key1)}`}</h6>
-            </td>
-            <td style={{ padding: "2px", verticalAlign: "top" }}>
-              <div dangerouslySetInnerHTML={{ __html: data[key1] }} />
-            </td>
-          </tr>
-        )}
-        {data[key2] && (
-          <tr>
-            <td
-              style={{ padding: "4px 2px", verticalAlign: "top", width: "30%" }}
-            >
-              <h6 key={key2}>{`${modifyKey(key2)}`}</h6>
-            </td>
-            <td style={{ padding: "2px", verticalAlign: "top" }}>
-              <div dangerouslySetInnerHTML={{ __html: data[key2] }} />
-            </td>
-          </tr>
-        )}
-      </tbody>
-    </table>
+    <ul className="data-list">
+      {data[key1] && (
+        <li className="data-list-item">
+          <h3 className="data-list-label">{modifyKey(key1)}</h3>
+          <div className="data-list-value">
+            <p className="data-list-value-text">
+              {htmlParsedValue(data[key1])}
+            </p>
+          </div>
+        </li>
+      )}
+      {data[key2] && (
+        <li className="data-list-item">
+          <h3 className="data-list-label">{modifyKey(key2)}</h3>
+          <div className="data-list-value">
+            <p className="data-list-value-text">
+              {htmlParsedValue(data[key2])}
+            </p>
+          </div>
+        </li>
+      )}
+    </ul>
   );
 };
 
@@ -176,10 +177,11 @@ export default function CollapsibleCard({
   defaultExpand,
   parentCollection
 }) {
-  const [expanded, setExpanded] = React.useState(defaultExpand);
+  const [expanded, setExpanded] = useState(true);
 
-  const handleExpandClick = () => {
-    setExpanded(!expanded);
+  const handleExpandClick = (e) => {
+    e.preventDefault();
+    setExpanded((prev) => !prev);
   };
 
   let facetSearchItems = [
@@ -190,47 +192,41 @@ export default function CollapsibleCard({
     "tags"
   ];
 
-  const renderContent = (key, value, index) => {
+  const renderContent = (key, value) => {
     if (typeof value === "string" && value.includes("<a href=")) {
-      return <div key={index}>{htmlParsedValue(value)}</div>;
+      return htmlParsedValue(value);
     } else if (typeof value === "string" && value.startsWith("http")) {
       return (
-        <div key={index}>
-          <a href={value} target="_blank" rel="noopener noreferrer">
-            {value}
-          </a>
-        </div>
+        <a href={value} target="_blank" rel="noopener noreferrer">
+          {value}
+        </a>
       );
     } else if (facetSearchItems.includes(key)) {
       return (
-        <div key={index}>
-          <a
-            href={`/search?q=&field=all&view=Gallery&${key}=${value}`}
-            rel="noopener noreferrer"
-          >
-            {value}
-          </a>
-        </div>
+        <a
+          href={`/search?q=&field=all&view=Gallery&${key}=${value}`}
+          rel="noopener noreferrer"
+        >
+          {value}
+        </a>
       );
     } else if (key === "language") {
       return (
-        <div key={index}>
-          <a
-            href="https://en.wikipedia.org/wiki/English_language"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            en
-          </a>
-        </div>
+        <a
+          href="https://en.wikipedia.org/wiki/English_language"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          en
+        </a>
       );
     } else {
-      return <div key={index}>{value}</div>;
+      return value;
     }
   };
 
   const getAboutData = (data) => {
-    let items = [
+    const items = [
       "description",
       "date",
       "rights",
@@ -240,68 +236,48 @@ export default function CollapsibleCard({
       "location",
       "visibility"
     ];
+
     return (
-      <table style={{ width: "100%", borderCollapse: "collapse" }}>
-        <tbody>
-          {single_value_headers.map((key) =>
-            data[key] && !items.includes(key) ? (
-              <tr key={key} style={{ padding: "4px 2px" }}>
-                <td
-                  style={{ padding: "2px", verticalAlign: "top", width: "30%" }}
-                >
-                  <h6>{modifyKey(key)}</h6>
-                </td>
-                <td style={{ padding: "2px", verticalAlign: "top" }}>
-                  {data[key] === "string" && data[key].startsWith("http") ? (
-                    <a
-                      href={data[key]}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {data[key]}
-                    </a>
-                  ) : (
-                    data[key]
-                  )}
-                </td>
-              </tr>
-            ) : null
-          )}
-          {multi_value_headers.map((key) =>
-            data[key] && !items.includes(key) && data[key].length > 0 ? (
-              <tr key={key} style={{ padding: "4px 2px" }}>
-                <td
-                  style={{ padding: "2px", verticalAlign: "top", width: "30%" }}
-                >
-                  <h6>{modifyKey(key)}</h6>
-                </td>
-                <td style={{ padding: "2px", verticalAlign: "top" }}>
-                  {/* {Array.isArray(data[key]) ? (
-                    data[key].map((value, index) =>
-                      typeof value === "string" && value.startsWith("http") ? (
-                        <div key={index}>
-                          <a href={value} target="_blank" rel="noopener noreferrer">
-                            {value}
-                          </a>
-                        </div>
-                      ) : (
-                        <div key={index}>{value}</div>
-                      )
-                    )
-                  ) : (
-                    data[key]
-                  )} */}
-                  {Array.isArray(data[key])
-                    ? data[key].map((value, index) =>
-                        renderContent(key, value, index)
-                      )
-                    : renderContent(data[key], 0)}
-                </td>
-              </tr>
-            ) : null
-          )}
-        </tbody>
-      </table>
+      <ul className="data-list">
+        {single_value_headers.map((key) =>
+          data[key] && !items.includes(key) ? (
+            <li key={key} className="data-list-item">
+              <h3 className="data-list-label">{modifyKey(key)}</h3>
+              <p className="data-list-value">
+                {typeof data[key] === "string" &&
+                data[key].startsWith("http") ? (
+                  <a href={data[key]} target="_blank" rel="noopener noreferrer">
+                    {data[key]}
+                  </a>
+                ) : (
+                  data[key]
+                )}
+              </p>
+            </li>
+          ) : null
+        )}
+
+        {multi_value_headers.map((key) =>
+          data[key] && !items.includes(key) && data[key].length > 0 ? (
+            <li key={key} className="data-list-item">
+              <h3 className="data-list-label">{modifyKey(key)}</h3>
+              <div className="data-list-value">
+                {Array.isArray(data[key]) ? (
+                  data[key].map((value, index) => (
+                    <p key={index} className="data-list-value-text">
+                      {renderContent(key, value)}
+                    </p>
+                  ))
+                ) : (
+                  <p className="data-list-value-text">
+                    {renderContent(key, data[key])}
+                  </p>
+                )}
+              </div>
+            </li>
+          ) : null
+        )}
+      </ul>
     );
   };
 
@@ -324,43 +300,32 @@ export default function CollapsibleCard({
     }
   };
 
+  const getCollapsibleArrow = () => {
+    return expanded ? (
+      <FontAwesomeIcon
+        className="expand-icon"
+        icon={faAngleDown}
+        aria-hidden="true"
+      />
+    ) : (
+      <FontAwesomeIcon
+        className="expand-icon"
+        icon={faAngleRight}
+        aria-hidden="true"
+      />
+    );
+  };
+
   return (
-    <Card sx={{ width: "100%", marginBottom: "1vh" }}>
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          backgroundColor: "#861f41",
-          color: "white",
-          fontSize: "2rem"
-        }}
-      >
-        <CardHeader
-          avatar={getMarker(marker)}
-          title={title}
-          titleTypographyProps={{ style: { fontSize: "0.55em" } }}
-          style={{ padding: "0.2em" }}
-        />
-        <CardActions disableSpacing>
-          <ExpandMore
-            expand={expanded}
-            onClick={handleExpandClick}
-            aria-expanded={expanded}
-            aria-label="show more"
-            style={{ padding: "2px" }}
-          >
-            <ExpandMoreIcon
-              style={{ padding: "2px", color: "white", fontSize: "2rem" }}
-            />
-          </ExpandMore>
-        </CardActions>
+    <details className="card-details" open={expanded}>
+      <summary className="card-summary" onClick={handleExpandClick}>
+        {getMarker(marker)}
+        {title}
+        {getCollapsibleArrow()}
+      </summary>
+      <div className="card-content">
+        {getContent(marker, data, site, parentCollection)}
       </div>
-      <Collapse in={expanded} timeout="auto" unmountOnExit>
-        <CardContent className="card-content">
-          {getContent(marker, data, site, parentCollection)}
-        </CardContent>
-      </Collapse>
-    </Card>
+    </details>
   );
 }

--- a/src/components/CollapsibleCards.js
+++ b/src/components/CollapsibleCards.js
@@ -177,7 +177,7 @@ export default function CollapsibleCard({
   defaultExpand,
   parentCollection
 }) {
-  const [expanded, setExpanded] = useState(true);
+  const [expanded, setExpanded] = useState(defaultExpand ?? true);
 
   const handleExpandClick = (e) => {
     e.preventDefault();

--- a/src/css/ArchivePage.scss
+++ b/src/css/ArchivePage.scss
@@ -24,6 +24,12 @@ div.item-image-section img.item-img {
   width: 100%;
 }
 
+.item-details-section .collapsible-cards-container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
 .dataContainer {
   display: flex;
   width: 100%;

--- a/src/css/Citation.scss
+++ b/src/css/Citation.scss
@@ -4,10 +4,33 @@
   position: relative;
 }
 
+.citation .citation-tab-list {
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid #ccc;
+}
+
 .citation .citation-tab {
+  border: 0;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  padding: 0.5rem 1rem;
   font-family: "gineso-condensed", sans-serif;
-  font-size: 1.05rem;
-  text-transform: none;
+  font-size: 1.1rem;
+
+  &:focus-visible {
+    outline: var(--focus_outline);
+    outline-offset: var(--focus-outline__offset);
+  }
+}
+
+.citation .citation-tab.is-active {
+  border-bottom-color: var(--vt-maroon);
+  color: var(--vt-maroon);
+}
+
+.citation .citation-tab[aria-selected="false"]:hover {
+  color: var(--vt-maroon);
 }
 
 .citation .citation-tab-content {
@@ -35,6 +58,15 @@
   font-size: 13px;
   padding: 5px 10px;
   border-radius: 0.2rem;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: var(--focus_outline);
+    outline-offset: var(--focus-outline__offset);
+  }
 }
 
 .citation .citation-tab-content .citation-text {

--- a/src/css/Citation.scss
+++ b/src/css/Citation.scss
@@ -25,9 +25,10 @@
 }
 
 .citation .citation-tab-content .copy-button-container .heading {
+  font-size: 0.95rem;
   font-family: "Acherus", sans-serif !important;
   font-weight: 500;
-  margin: 0 !important;
+  margin: 0;
 }
 
 .citation .citation-tab-content .copy-button-container .citation-copy-button {
@@ -39,11 +40,15 @@
 .citation .citation-tab-content .citation-text {
   padding: 0.5rem;
   line-height: 1.35rem;
+  font-family: "Lato", sans-serif !important;
+  font-size: 0.88rem;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .citation .citation-tab-content .citation-text a {
-  font-family: "Acherus", sans-serif !important;
-  font-size: 14px !important;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .citation .citation-tab-content pre {

--- a/src/css/Citation.scss
+++ b/src/css/Citation.scss
@@ -6,22 +6,21 @@
 
 .citation .citation-tab-list {
   display: flex;
+  margin: 0;
+  padding: 0;
   gap: 0.25rem;
+  list-style: none;
   border-bottom: 1px solid #ccc;
 }
 
 .citation .citation-tab {
+  display: block;
   border: 0;
   border-bottom: 2px solid transparent;
   background: transparent;
   padding: 0.5rem 1rem;
   font-family: "gineso-condensed", sans-serif;
   font-size: 1.1rem;
-
-  &:focus-visible {
-    outline: var(--focus_outline);
-    outline-offset: var(--focus-outline__offset);
-  }
 }
 
 .citation .citation-tab.is-active {
@@ -58,15 +57,6 @@
   font-size: 13px;
   padding: 5px 10px;
   border-radius: 0.2rem;
-
-  &:focus {
-    outline: none;
-  }
-
-  &:focus-visible {
-    outline: var(--focus_outline);
-    outline-offset: var(--focus-outline__offset);
-  }
 }
 
 .citation .citation-tab-content .citation-text {

--- a/src/css/CollapsibleCards.scss
+++ b/src/css/CollapsibleCards.scss
@@ -14,6 +14,15 @@
   font-size: 1.1rem;
   border-radius: 0.3rem;
   list-style: none;
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    outline: var(--focus_outline);
+    outline-offset: var(--focus-outline__offset);
+  }
 }
 
 .card-summary .card-summary-icon {

--- a/src/css/CollapsibleCards.scss
+++ b/src/css/CollapsibleCards.scss
@@ -1,39 +1,79 @@
-/* Default padding for CardContent */
-.card-content {
-  padding: 16px;
+.card-details {
+  width: 100%;
+  border-radius: 0.3rem;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
-.card-header {
+.card-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem 0.8rem;
   background-color: #861f41;
   color: white;
-  font-size: 2rem;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-}
-.expand-more-icon {
-  color: white;
-  font-size: 2rem;
+  font-size: 1.1rem;
+  border-radius: 0.3rem;
+  list-style: none;
 }
 
-.card-content table {
-  width: "80%";
-  border-collapse: "collapse";
-  border: none;
+.card-summary .card-summary-icon {
+  font-size: 1.2rem;
+  width: 1.25rem;
+  display: inline-flex;
 }
 
-.card-content th {
-  border: none;
-  padding: 8px;
+.card-summary .expand-icon {
+  margin-right: 0;
+  margin-left: auto;
+  font-size: 1.2rem;
 }
 
-.card-content td {
-  border: none;
-  padding: 8px;
-  text-align: left;
-  overflow-wrap: break-word; /* Allow text to wrap inside the cell */
-  word-wrap: break-word; /* For older browsers */
-  white-space: normal;
+.card-details[open] .card-summary {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.card-content {
+  padding: 1rem;
+
+  .data-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  .data-list-item {
+    display: grid;
+    grid-template-columns: minmax(140px, 25%) 1fr;
+    gap: 0.75rem;
+    padding: 0.31rem 0;
+    align-items: start;
+  }
+
+  .data-list-label {
+    font-weight: 500;
+    font-size: 1.0625rem;
+    font-family: "gineso-condensed", sans-serif;
+    margin: 0;
+  }
+
+  .data-list-value {
+    font-family: "Lato", sans-serif !important;
+    font-size: 0.88rem;
+    min-width: 0;
+    word-break: break-word;
+    margin: 0;
+  }
+
+  .data-list-value-text {
+    font-family: "Lato", sans-serif !important;
+    font-size: 0.88rem;
+    margin: 0;
+  }
+
+  .data-list-value-text + .data-list-value-text {
+    margin-top: 0.3rem;
+  }
 }
 
 .section-wrapper {
@@ -52,11 +92,10 @@
 
 @media (max-width: 600px) {
   .card-content {
-    padding: 8px; /* Reduced padding for mobile devices */
+    padding: 0.7rem;
   }
 
-  .card-content th,
-  .card-content td {
-    font-size: 0.8rem; /* Smaller font size for better readability on small screens */
+  .card-content .data-list-item {
+    gap: 0.35rem;
   }
 }

--- a/src/css/CollapsibleCards.scss
+++ b/src/css/CollapsibleCards.scss
@@ -1,10 +1,10 @@
-.card-details {
+details.card-details {
   width: 100%;
   border-radius: 0.3rem;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
 }
 
-.card-summary {
+details summary.card-summary {
   display: flex;
   align-items: center;
   gap: 0.5rem;
@@ -26,24 +26,32 @@
   }
 }
 
-.card-summary .card-summary-icon {
+details summary.card-summary .card-summary-icon {
   font-size: 1.2rem;
   width: 1.25rem;
   display: inline-flex;
 }
 
-.card-summary .expand-icon {
+details summary.card-summary .expand-icon {
   margin-right: 0;
   margin-left: auto;
   font-size: 1.2rem;
 }
 
-.card-details[open] .card-summary {
+details.card-details .expand-icon {
+  transform: rotate(-90deg);
+}
+
+details.card-details[open] .expand-icon {
+  transform: rotate(0deg);
+}
+
+details.card-details[open] summary.card-summary {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
 
-.card-content {
+details.card-details .card-content {
   padding: 1rem;
 
   .data-list {
@@ -55,34 +63,41 @@
   .data-list-item {
     display: grid;
     grid-template-columns: minmax(140px, 25%) 1fr;
-    gap: 0.75rem;
-    padding: 0.31rem 0;
     align-items: start;
+  }
+
+  .data-list-item + .data-list-item {
+    margin-top: 0.75rem;
+  }
+
+  .data-list-item > dt {
+    grid-column: 1;
+    margin: 0;
+  }
+
+  .data-list-item > dd {
+    grid-column: 2;
+    margin: 0;
+  }
+
+  .data-list-item > dd + dd {
+    margin-top: 0.35rem;
   }
 
   .data-list-label {
     font-weight: 500;
     font-size: 1.0625rem;
     font-family: "gineso-condensed", sans-serif;
-    margin: 0;
   }
 
   .data-list-value {
     font-family: "Lato", sans-serif !important;
     font-size: 0.88rem;
-    min-width: 0;
     word-break: break-word;
-    margin: 0;
-  }
-
-  .data-list-value-text {
-    font-family: "Lato", sans-serif !important;
-    font-size: 0.88rem;
-    margin: 0;
-  }
-
-  .data-list-value-text + .data-list-value-text {
-    margin-top: 0.3rem;
+    & a,
+    & a:visited {
+      text-decoration: underline !important;
+    }
   }
 }
 

--- a/src/css/CollapsibleCards.scss
+++ b/src/css/CollapsibleCards.scss
@@ -13,6 +13,7 @@
   color: white;
   font-size: 1.1rem;
   border-radius: 0.3rem;
+  user-select: none;
   list-style: none;
 
   &:focus {

--- a/src/css/CollapsibleCards.scss
+++ b/src/css/CollapsibleCards.scss
@@ -32,13 +32,11 @@ details summary.card-summary .card-summary-icon {
   display: inline-flex;
 }
 
-details summary.card-summary .expand-icon {
+details.card-details .expand-icon {
   margin-right: 0;
   margin-left: auto;
   font-size: 1.2rem;
-}
-
-details.card-details .expand-icon {
+  transition: 0.3s ease;
   transform: rotate(-90deg);
 }
 

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -428,21 +428,21 @@ class ArchivePage extends Component {
                       title="Copyright"
                       marker="copyright"
                       data={this.state.item}
-                      defaultExpand={false}
+                      defaultExpand={true}
                     />
                     <CollapsibleCard
                       title="Citation"
                       marker="citation"
                       data={this.state.item}
                       site={this.props.site}
-                      defaultExpand={false}
+                      defaultExpand={true}
                       parentCollection={this.state.topLevelParentCollection}
                     />
                     <CollapsibleCard
                       title="Location"
                       marker="location"
                       data={this.state.item}
-                      defaultExpand={false}
+                      defaultExpand={true}
                     />
                   </div>
                 </div>

--- a/src/pages/archives/ArchivePage.js
+++ b/src/pages/archives/ArchivePage.js
@@ -417,7 +417,7 @@ class ArchivePage extends Component {
                       )}
                     </div>
                   </div>
-                  <div>
+                  <div className="collapsible-cards-container">
                     <CollapsibleCard
                       title="About"
                       marker="about"


### PR DESCRIPTION

## Replaced MUI-based archive metadata collapsible cards and citation UI with simpler semantic HTML and improved keyboard/focus accessibility.


## 🔗 Asana, 4Help, and Related Links [REQUIRED]  
**Asana Ticket**: https://app.asana.com/1/955176856078227/project/1210742763721034/task/1213423239070608?focus=true



## ✨ What Does This Pull Request Do?  [REQUIRED]
Improved the semantic structure of the archive page metadata section by using more meaningful markup for collapsible cards and metadata content, improve heading usage. Updated citation component to use accessible custom tabs and more consistent focus ring styling.
   
## 🛠️ Summary of Changes [REQUIRED]
- replaced the archive metadata cards’ MUI card/collapse layout with native details/summary accordions
- converted the metadata and copyright sections from table-based markup to semantic unordered lists
- refactored the Citation component tabs to use regular buttons, cleaned up sample citation styles, including heading/text semantics, copy button focus styles, and better wrapping for long links
   
## 🧪 How Should PR Be Tested? [REQUIRED]
- go to [generated preview](https://kl-a11y.d1n265krqy0ld3.amplifyapp.com/), and go to any archive page
- check that each collapsible card can be expanded and collapsed with both mouse and keyboard, and that the `summary` shows a visible focus ring when tabbed to.
- in the 'Citation' card, switch between `Citation` and `BibTeX` tabs using both mouse and keyboard arrow keys, and confirm the active tab and visible panel update correctly.
- resize to a different viewports and confirm the card layout, metadata rows, and citation text wrap cleanly and responsive


   
## ♿ Accessibility Testing [REQUIRED]
**Complete standard accessibility testing and provide additional test steps/details, if applicable:**  
- [x] Does this PR change anything in the front-end? This includes backend-only changes that may affect front end components (data schema changes, global configs, package version updates, etc.)

**If "Yes", provide test environment details and complete or mark N/A all of the following tests:**

OS/Browser/Screen reader details: *For Example: macOS Tahoe 26.0.1, Google Chrome v141.0.7390.55, VoiceOver v10*

- [x] Complete an axe DevTools full or partial page scans and link it here ([axe DevTools scanning docs](https://docs.deque.com/devtools-for-web/4/en/devtools-scanning))
- [x] Keyboard navigability: Focus ring showing on all focusable/interactive elements in expected order, standard interaction present ([keyboard testing basics](https://knowbility.org/blog/2018/keyboard-testing-basics/))
- [x] Screen reader comprehension: No elements hidden from screen reader, alt text, no repeated text ([screen reader keyboard shortcuts](https://dequeuniversity.com/screenreaders/)) 
- [x] Color contrast at least WCAG AA ([contrast checker](https://webaim.org/resources/contrastchecker/))
- [x] Accessible markup used (e.g., proper heading levels, labels, roles, and semantic HTML as much as possible)  
- [ ] Other accessibility testing (please describe):  


## 👥 Interested Parties  

Tag any reviewers or stakeholders you'd like to include in the discussion:   
@whunter @ervinkellym @padma012 @goynejennifer 

---

🚨[REQUIRED] -  Required fields/information in the pull request
