### PR TITLE
Hides SubCollectionsTree if no sub-collections

### DIFF
--- a/src/css/CollectionsShowPage.scss
+++ b/src/css/CollectionsShowPage.scss
@@ -232,6 +232,11 @@ span.creator:after {
     border-bottom: 1px solid var(--dark-gray);
     border-right: none;
   }
+  .mid-content-row .details-section.no-map,
+  .mid-content-row.list-view .details-section.no-map {
+    border-right: none;
+    border-bottom: none;
+  }
 }
 
 .mid-content-row .details-section-header {

--- a/src/pages/collections/CollectionsShowPage/CollectionMetadataSection.tsx
+++ b/src/pages/collections/CollectionsShowPage/CollectionMetadataSection.tsx
@@ -27,11 +27,7 @@ export const CollectionMetadataSection: FC<Props> = ({
   const { collectionMap, expanded, handleToggle } = useLoadMap(collection);
   if (collection) {
     const needsMap = () => {
-      return (
-        collectionMap &&
-        collectionMap.children.length &&
-        collection.collection_category !== "iawa"
-      );
+      return collectionMap && collectionMap.children.length;
     };
     return (
       <>

--- a/src/pages/collections/CollectionsShowPage/CollectionMetadataSection.tsx
+++ b/src/pages/collections/CollectionsShowPage/CollectionMetadataSection.tsx
@@ -27,7 +27,7 @@ export const CollectionMetadataSection: FC<Props> = ({
   const { collectionMap, expanded, handleToggle } = useLoadMap(collection);
   if (collection) {
     const needsMap = () => {
-      return collectionMap && collectionMap.children.length;
+      return collectionMap?.children?.length;
     };
     return (
       <>

--- a/src/pages/collections/CollectionsShowPage/CollectionMetadataSection.tsx
+++ b/src/pages/collections/CollectionsShowPage/CollectionMetadataSection.tsx
@@ -4,6 +4,7 @@ import { RenderItemsDetailed } from "../../../lib/MetadataRenderer";
 import "../../../css/CollectionsShowPage.scss";
 import { CollectionDescription } from "./CollectionDescription";
 import { language_codes } from "../../../lib/language_codes";
+import { useLoadMap } from "./useLoadMap";
 
 const languages = language_codes["abbr"];
 
@@ -23,13 +24,24 @@ export const CollectionMetadataSection: FC<Props> = ({
   site,
   collectionCustomKey
 }) => {
+  const { collectionMap, expanded, handleToggle } = useLoadMap(collection);
   if (collection) {
+    const needsMap = () => {
+      return (
+        collectionMap &&
+        collectionMap.children.length &&
+        collection.collection_category !== "iawa"
+      );
+    };
     return (
       <>
         <div
           className={`${
-            viewOption === "list" ? "col-12" : "col-12 col-lg-8"
-          } details-section`}
+            viewOption === "list" || !needsMap()
+              ? "col-12 "
+              : "col-12 col-lg-8 "
+          }
+            details-section ${!needsMap() ? "no-map" : ""}`}
           role="region"
           aria-labelledby="collection-details-section-header"
         >
@@ -75,7 +87,12 @@ export const CollectionMetadataSection: FC<Props> = ({
           role="region"
           aria-labelledby="collection-subcollections-section"
         >
-          <SubCollectionsTree collection={collection} />
+          <SubCollectionsTree
+            collection={collection}
+            collectionMap={collectionMap}
+            expanded={expanded}
+            handleToggle={handleToggle}
+          />
         </div>
       </>
     );

--- a/src/pages/collections/CollectionsShowPage/SubCollectionsTree.tsx
+++ b/src/pages/collections/CollectionsShowPage/SubCollectionsTree.tsx
@@ -18,7 +18,7 @@ export const SubCollectionsTree: FC<Props> = ({
   expanded,
   handleToggle
 }) => {
-  if (!collectionMap || !collectionMap.children.length) {
+  if (!collectionMap || !collectionMap?.children?.length) {
     return <></>;
   }
 

--- a/src/pages/collections/CollectionsShowPage/SubCollectionsTree.tsx
+++ b/src/pages/collections/CollectionsShowPage/SubCollectionsTree.tsx
@@ -18,11 +18,7 @@ export const SubCollectionsTree: FC<Props> = ({
   expanded,
   handleToggle
 }) => {
-  if (
-    !collectionMap ||
-    !collectionMap.children.length ||
-    collection.collection_category === "iawa"
-  ) {
+  if (!collectionMap || !collectionMap.children.length) {
     return <></>;
   }
 

--- a/src/pages/collections/CollectionsShowPage/SubCollectionsTree.tsx
+++ b/src/pages/collections/CollectionsShowPage/SubCollectionsTree.tsx
@@ -1,17 +1,29 @@
-import { FC } from "react";
+import { FC, SyntheticEvent } from "react";
 import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";
 import SvgIcon from "@mui/material/SvgIcon";
-import { useLoadMap } from "./useLoadMap";
 import { CollectionTreeItem } from "./CollectionTreeItem";
 
 type Props = {
   collection: Collection;
+  collectionMap: MapObject | null;
+  expanded: string[] | undefined;
+  handleToggle: (
+    event: SyntheticEvent<Element, Event>,
+    itemIds: string[]
+  ) => void;
 };
-export const SubCollectionsTree: FC<Props> = ({ collection }) => {
-  const { collectionMap, expanded, handleToggle } = useLoadMap(collection);
-
-  if (!collectionMap) {
-    return <div>Loading...</div>;
+export const SubCollectionsTree: FC<Props> = ({
+  collection,
+  collectionMap,
+  expanded,
+  handleToggle
+}) => {
+  if (
+    !collectionMap ||
+    !collectionMap.children.length ||
+    collection.collection_category === "iawa"
+  ) {
+    return <></>;
   }
 
   const CollapseIcon = () => {


### PR DESCRIPTION
## Title of Pull Request(PR) [REQUIRED]   
Hides `<SubCollectionsTree>` component on `<CollectionShowPage>` if collection has no child collections 



## 🔗 Asana, 4Help, and Related Links [REQUIRED]  
**Asana Ticket**: [Insert link]  
**4Help Ticket (if applicable)**: [Insert link]  
**Other References**: [PRs, notes, design files, docs]  



## ✨ What Does This Pull Request Do?  [REQUIRED]
**Briefly describe the goal of this PR and what problem it solves.**  
*  Refactors CollectionShowPage and SubCollectionsTree to only show tree nav if the collection has sub-collections
*  Adjusts CollectionShowPage styles to expand metadata section across entire "row" when no SubCollectionsTree


   
## 🛠️ Summary of Changes [REQUIRED]
**Provide an overview of the technical changes and any relevant details. 
List key updates, features added/removed, or issues addressed.**   
**For Example:**  
* Moved `useLoadMap()` hook to CollectionShowPage so we can determine if the component is needed from outside of the component
* Added props to support loading tree in CollectionShowPage and passing tree to SubCollectionsTree if appropriate
* Temporarily hardcoded `iawa` collection_category as reason to hide SubCollectionsTree (until IAWA collectionmaps can be regenerated w/ no sub-collections)
* Adds bootstrap class to metadata section to tell it to take 100% of horizontal space when SubCollectionsTree is hidden.


   
## 🧪 How Should PR Be Tested? [REQUIRED]
**Provide detailed steps for how reviewers can test or reproduce the changes.**  
* Visit https://hide-subcollectionstree.d1n265krqy0ld3.amplifyapp.com/collection/jr37z18t
* Check that SubCollectionsTree is NOT rendered and metadata section gets 100% horizontal space  
* Visit https://no-hide-subcollectionstree.d1n265krqy0ld3.amplifyapp.com/collection/c4022d52 (running same commit)
* Check that SubCollectionsTree DOES still render for collections that contain sub-collections


   
## ♿ Accessibility Testing [REQUIRED]
**Complete standard accessibility testing and provide additional test steps/details, if applicable:**  
- [x] Does this PR change anything in the front-end? This includes backend-only changes that may affect front end components (data schema changes, global configs, package version updates, etc.)

**If "Yes", provide test environment details and complete or mark N/A all of the following tests:**

OS/Browser/Screen reader details: *For Example: macOS Tahoe 26.0.1, Google Chrome v141.0.7390.55, VoiceOver v10*

- [x] Complete an axe DevTools full or partial page scans and link it here ([axe DevTools scan results](https://axe.deque.com/axe-devtools/tests/1b2af667-365a-45ee-bf7c-1d872e16c391?configWCAGLevel=wcag21aa&configAccessibilityStandard=wcag21aa&configBestPractices=enabled&configAdvancedRules=disabled&configNeedsReview=exclude))
- [x] Keyboard navigability: Focus ring showing on all focusable/interactive elements in expected order, standard interaction present ([keyboard testing basics](https://knowbility.org/blog/2018/keyboard-testing-basics/))
- [x] Screen reader comprehension: No elements hidden from screen reader, alt text, no repeated text ([screen reader keyboard shortcuts](https://dequeuniversity.com/screenreaders/)) 
- [x] Color contrast at least WCAG AA ([contrast checker](https://webaim.org/resources/contrastchecker/))
- [x] Accessible markup used (e.g., proper heading levels, labels, roles, and semantic HTML as much as possible)  
- [ ] Other accessibility testing (please describe):  


   
## 📝 Additional Notes 
**Any extra context that would help reviewers. Consider the following:**  
* branch: `hide-SubCollectionsTree`


   
## 👥 Interested Parties  

Tag any reviewers or stakeholders you'd like to include in the discussion:   
@goynejennifer 
@badmintoncat 

---

🚨[REQUIRED] -  Required fields/information in the pull request
