### PR TITLE
fix(a11y): make plain URLs clickable in metadata

### DIFF
--- a/src/components/CollapsibleCards.js
+++ b/src/components/CollapsibleCards.js
@@ -6,7 +6,7 @@ import {
   faLocationDot
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { htmlParsedValue } from "src/lib/MetadataRenderer";
+import { htmlParsedValue, cleanHTML } from "src/lib/MetadataRenderer";
 import Citation from "../components/Citation";
 import "../css/CollapsibleCards.scss";
 import "../css/Typography.scss";
@@ -147,13 +147,25 @@ const getCopyrightData = (data) => {
       {data[key1] && (
         <div className="data-list-item">
           <dt className="data-list-label">{modifyKey(key1)}</dt>
-          <dd className="data-list-value">{htmlParsedValue(data[key1])}</dd>
+          <dd className="data-list-value">
+            {cleanHTML(String(data[key1]), "html")}
+          </dd>
         </div>
       )}
       {data[key2] && (
         <div className="data-list-item">
           <dt className="data-list-label">{modifyKey(key2)}</dt>
-          <dd className="data-list-value">{htmlParsedValue(data[key2])}</dd>
+          {Array.isArray(data[key2]) ? (
+            data[key2].map((value, index) => (
+              <dd key={index} className="data-list-value">
+                {cleanHTML(String(value), "html")}
+              </dd>
+            ))
+          ) : (
+            <dd className="data-list-value">
+              {cleanHTML(String(data[key2]), "html")}
+            </dd>
+          )}
         </div>
       )}
     </dl>

--- a/src/lib/MetadataRenderer.js
+++ b/src/lib/MetadataRenderer.js
@@ -4,6 +4,52 @@ import "../css/ListPages.scss";
 import parse from "html-react-parser";
 import sanitizeHtml from "sanitize-html";
 
+/**
+ * Auto-detects URLs in text and converts them to proper <a href="..."> elements.
+ * Also fixes <a> tags that are missing href attributes.
+ *
+ * @param {string} html - The HTML content to process
+ * @returns {string} - HTML with properly formatted links
+ */
+function autoLinkHTML(html) {
+  if (!html || typeof html !== "string") {
+    return html;
+  }
+
+  // Step 1: Fix <a> tags without href attribute
+  // Match: <a>URL</a> or <a ...attributes...>URL</a> where href is missing
+  html = html.replace(
+    /<a(?![^>]*href=)([^>]*)>((?:https?:\/\/|www\.)[^\s<]+)<\/a>/gi,
+    (match, attrs, url) => {
+      // If URL starts with www., add https://
+      const fullUrl = url.startsWith("www.") ? `https://${url}` : url;
+      // Preserve any existing attributes
+      return `<a href="${fullUrl}"${attrs}>${url}</a>`;
+    }
+  );
+
+  // Step 2: Auto-detect and wrap plain URLs that aren't already in anchor tags
+  // This regex matches URLs that are NOT already inside <a> tags
+  // Match URLs: http://, https://, or www.
+  const urlRegex =
+    /(?<!<a[^>]*>)(?<!href=["'])(?<!src=["'])((?:https?:\/\/|www\.)[^\s<>"']+)(?![^<]*<\/a>)/gi;
+
+  html = html.replace(urlRegex, (match) => {
+    // Check if this URL is inside an existing tag's attribute
+    // Simple heuristic: if preceded by = within 5 chars, it's likely an attribute
+    const beforeMatch = html.substring(0, html.indexOf(match));
+    if (beforeMatch.slice(-5).includes("=")) {
+      return match; // Don't wrap URLs in attributes
+    }
+
+    // Add https:// prefix for www. URLs
+    const href = match.startsWith("www.") ? `https://${match}` : match;
+    return `<a href="${href}">${match}</a>`;
+  });
+
+  return html;
+}
+
 export function cleanHTML(content, type) {
   let options;
   if (type === "transcript") {
@@ -152,9 +198,13 @@ export function cleanHTML(content, type) {
   } else {
     options = null;
   }
+
+  // Auto-detect and fix links in the HTML content before sanitizing
+  const linkedContent = autoLinkHTML(content);
+
   let cleaned = options
-    ? parse(sanitizeHtml(content, options))
-    : parse(sanitizeHtml(content));
+    ? parse(sanitizeHtml(linkedContent, options))
+    : parse(sanitizeHtml(linkedContent));
   return cleaned;
 }
 

--- a/src/pages/MetadataPage.js
+++ b/src/pages/MetadataPage.js
@@ -3,6 +3,7 @@ import { Helmet } from "react-helmet";
 import { API, graphqlOperation } from "aws-amplify";
 import { SiteTitle } from "../components/SiteTitle";
 import { buildHeaderSchema } from "../lib/richSchemaTools";
+import { cleanHTML } from "../lib/MetadataRenderer";
 import { listMetadataFields } from "../graphql/queries";
 import metadataFieldInfo from "../data/metadataFieldInfo.json";
 
@@ -301,9 +302,13 @@ class MetadataPage extends Component {
                               )}
                             </td>
                             <td className="type">{field.type}</td>
-                            <td className="description">{field.description}</td>
+                            <td className="description">
+                              {cleanHTML(String(field.description), "html")}
+                            </td>
                             <td className="example">
-                              <code>{field.example}</code>
+                              <code>
+                                {cleanHTML(String(field.example), "html")}
+                              </code>
                             </td>
                           </tr>
                         ))}


### PR DESCRIPTION
## Title of Pull Request(PR) [REQUIRED]   
fix(a11y): make plain URLs clickable in metadata



## 🔗 Asana, 4Help, and Related Links [REQUIRED]  
**Asana Ticket**: https://app.asana.com/1/955176856078227/project/1210742763721034/task/1213363294923210?focus=true

## ✨ What Does This Pull Request Do?  [REQUIRED]

Fixes accessibility issue where URLs in metadata fields were displaying as plain text instead of clickable links 
Around 12k broken links found across preprod db where URLs were either plain text or inside `<a>` tags without `href` attributes. 95% of these were in the Copyright section's `rights` field

   
## 🛠️ Summary of Changes [REQUIRED]
- **Added** `autoLinkHTML()` function in MetadataRenderer.js that:
  - Detects plain URLs (http://, https://, www.)
  - Fixes broken `<a>` tags missing href attribute
  - Wraps URLs in proper `<a href="...">` tags
- **Integrated** autoLinkHTML into cleanHTML() pipeline (runs before sanitization)
- **Fixed** CollapsibleCards Copyright section: replaced `htmlParsedValue()` with `cleanHTML()` to apply the fix
- **Added** array handling for `rights` field (can have multiple values)
- **Applies to** metadata fields: rights, rights_holder, metadata fields: description and examples

 
## 🧪 How Should PR Be Tested? [REQUIRED]

**Currently tested in vtdlpdev and vtdlp-pprd environments.**  

- Archive item pages: Verified on `federated` (vtdlp-pprd) - rights/rights-holder URLs render as clickable links, including URLs embedded in surrounding text.
- Metadata guide page (/metadata): Verified on both federated and iawa - URLs in teh Description/Example columns render as clickable links.and `iawa` repository types on vtdlp-pprd - verified on archive item pages and the metadata guide page. 

**Note:** The link rendering lives in a shared component (`CollapsibleCards/cleanHTML`) and is identical across repository types - `REACT_APP_REP_TYPE` only filters which items load. `vtdlp-pprd` currently has no `iawa` archive items (categories present:` federated, hokies, podcasts, swva`), so archive-page `rights` links cant be shown under `iawa`. Verified on federated items containing `rights` URLs; the same code renders for all rep types.

Please test on the **ally** backend environment.

**Step 1**: Navigate to any archive detail page (e.g., search for an item and click to view details)

**Step 2**: Expand the **"Copyright"** collapsible card

**Step 3**: Verify the **Rights** and **Rights Holder** fields:

- URL renders as a styled, focusable link (color+underline)
- Cursor should change to pointer on hover
- Links should be clickable and open in browser
- Right-click should show link context menu 

**Step 4**: Confirm unrelated existing fields still render as before - e.g. a source field whose value is a full URL stays clickable, and facet fields like type/tags still work as search links. (These use pre-existing rendering, unchanged by this PR.)

**Step 5**: On the **Metadata Guide** (`/metadata`), confirm URLs in the **Description** and **Example** columns are clickable links.
   
## ♿ Accessibility Testing [REQUIRED]
**Complete standard accessibility testing and provide additional test steps/details, if applicable:**  
- [x] Does this PR change anything in the front-end? This includes backend-only changes that may affect front end components (data schema changes, global configs, package version updates, etc.)

**If "Yes", provide test environment details and complete or mark N/A all of the following tests:**

OS/Browser/Screen reader details: *For Example: macOS Tahoe 26.0.1, Google Chrome v141.0.7390.55, VoiceOver v10*

- [ ] Complete an axe DevTools full or partial page scans and link it here ([axe DevTools scanning docs](https://docs.deque.com/devtools-for-web/4/en/devtools-scanning))
- [ ] Keyboard navigability: Focus ring showing on all focusable/interactive elements in expected order, standard interaction present ([keyboard testing basics](https://knowbility.org/blog/2018/keyboard-testing-basics/))
- [ ] Screen reader comprehension: No elements hidden from screen reader, alt text, no repeated text ([screen reader keyboard shortcuts](https://dequeuniversity.com/screenreaders/)) 
- [ ] Color contrast at least WCAG AA ([contrast checker](https://webaim.org/resources/contrastchecker/))
- [ ] Accessible markup used (e.g., proper heading levels, labels, roles, and semantic HTML as much as possible)  
- [ ] Other accessibility testing (please describe):  


   
## 📝 Additional Notes 
**Any extra context that would help reviewers. Consider the following:**  
*What branch should be used for testing?  
*Does this introduce new dependencies?  
*Are documentation updates required?  
*Could this impact existing functionality?  


   
## 👥 Interested Parties  

Tag any reviewers or stakeholders you'd like to include in the discussion:   
@username

---

🚨[REQUIRED] -  Required fields/information in the pull request
