### PR TITLE
Show 'required' indicator on fields and move the indicator to the first column: metadata column name

### DIFF
--- a/src/css/MetadataPage.scss
+++ b/src/css/MetadataPage.scss
@@ -102,19 +102,20 @@
           font-weight: 600;
           color: #333;
           min-width: 150px;
+        }
 
-          .required-indicator {
-            display: inline-block;
-            font-size: 0.8rem;
-            font-weight: 500;
-            font-style: italic;
-            color: #850f21;
-            margin-top: 0.25rem;
-          }
+        .required-indicator {
+          display: inline-block;
+          font-size: 0.8rem;
+          font-weight: 500;
+          font-style: italic;
+          font-family: Arial, sans-serif;
+          color: #850f21;
+          margin-top: 0.25rem;
+        }
 
-          .conditional-indicator {
-            color: #850f21;
-          }
+        .conditional-indicator {
+          color: #850f21;
         }
 
         &.type {

--- a/src/pages/MetadataPage.js
+++ b/src/pages/MetadataPage.js
@@ -129,7 +129,7 @@ class MetadataPage extends Component {
     // Create CSV where each field is a column instead of a row
     const columnNames = metadataFields.map((field) => field.columnName);
     const labelNames = metadataFields.map((field) =>
-      field.required === true
+      field.required === "Yes"
         ? `${field.labelName} (Required)`
         : field.required === "Conditional"
         ? `${field.labelName} (Conditional)`
@@ -266,7 +266,7 @@ class MetadataPage extends Component {
                             field.columnName.toLowerCase().includes(query) ||
                             field.labelName.toLowerCase().includes(query) ||
                             field.type.toLowerCase().includes(query) ||
-                            (field.required === true &&
+                            (field.required === "Yes" &&
                               "required".includes(query)) ||
                             (field.required === "Conditional" &&
                               "conditional".includes(query)) ||
@@ -278,11 +278,8 @@ class MetadataPage extends Component {
                           <tr key={index}>
                             <th scope="row" className="column-name">
                               {field.columnName}
-                            </th>
-                            <td className="label-name">
-                              {field.required === true ? (
+                              {field.required === "Yes" ? (
                                 <>
-                                  {field.labelName}
                                   <br />
                                   <span className="required-indicator">
                                     (Required)
@@ -290,16 +287,14 @@ class MetadataPage extends Component {
                                 </>
                               ) : field.required === "Conditional" ? (
                                 <>
-                                  {field.labelName}
                                   <br />
                                   <span className="required-indicator conditional-indicator">
                                     (Conditional)
                                   </span>
                                 </>
-                              ) : (
-                                field.labelName
-                              )}
-                            </td>
+                              ) : null}
+                            </th>
+                            <td className="label-name">{field.labelName}</td>
                             <td className="type">{field.type}</td>
                             <td className="description">{field.description}</td>
                             <td className="example">


### PR DESCRIPTION
## Title of Pull Request(PR) [REQUIRED]   
Show 'required' indicator on fields and move the indicator to the first column: metadata column name

## ✨ What Does This Pull Request Do?  [REQUIRED]
- Fix field.required === true (boolean) to === "Yes" (string) in 3 places to match the actual string values stored in DynamoDB — the strict boolean check was introduced during DynamoDB integration and never matched the stored "Yes"/"No" string values, causing Required to never display
- Move Required/Conditional indicator from label name column to metadata column name column
- Move .required-indicator and .conditional-indicator CSS out of .label-name scope so styles apply in both columns, add font-family: Arial to prevent inheriting Courier New monospace from .column-name

      
## 🧪 How Should PR Be Tested? [REQUIRED]
Pull the updates and check to see if 'required' appears under the required fields in the first column: metadata column name
   
## 👥 Interested Parties  

Tag any reviewers or stakeholders you'd like to include in the discussion:   
@username

---

🚨[REQUIRED] -  Required fields/information in the pull request
